### PR TITLE
add edgium support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build:firefox": "webpack --config webpack.config.firefox.js",
     "build:chrome": "webpack --config webpack.config.chrome.js",
-    "build:edge": "webpack --config webpack.config.edge.js"
+    "build:edge": "webpack --config webpack.config.edge.js",
+    "build:edgium": "webpack --config webpack.config.edgium.js"
   }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -24,7 +24,7 @@
 //     port.postMessage(message);
 // }
 
-if (process.env.BROWSER === 'chrome') {
+if (process.env.BROWSER === 'chrome' || process.env.BROWSER === 'edgium' || process.env.BROWSER === 'edge') {
   chrome.runtime.onMessage.addListener(async function(
     data,
     sender,

--- a/webpack.config.edgium.js
+++ b/webpack.config.edgium.js
@@ -1,0 +1,28 @@
+const { dirname, join } = require('path');
+
+const { DefinePlugin } = require('webpack');
+
+const base = require('./webpack.base.config');
+const merge = require('webpack-merge');
+const ZipPlugin = require('zip-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
+
+module.exports = merge(base, {
+  output: {
+    path: join(__dirname, 'dist', 'edgium')
+  },
+  plugins: [
+    new CopyPlugin([
+      {
+        from: join(__dirname, 'src', 'manifest-chrome.json'),
+        to: 'manifest.json'
+      }
+    ]),
+    new DefinePlugin({
+      'process.env.BROWSER': JSON.stringify('edgium')
+    }),
+    new ZipPlugin({
+      filename: 'extension.zip'
+    })
+  ]
+});


### PR DESCRIPTION
Add build support for Microsoft's new Chromium-based Edge browser. Currently, there are no breaking differences between extension support between Edgium and Google Chrome, so they are using the same `manifest.json` file