### PR TITLE
Add Tidal support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "now-playing-extension",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "main": "",
   "author": "pendo324",
   "license": "MIT",

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -3,7 +3,7 @@
 
   "name": "Universal Now Playing Companion",
   "description": "Browser helper for the desktop application, Universal Now Playing",
-  "version": "1.0.0",
+  "version": "1.0.3",
 
   "icons": {
     "48": "icon.png"

--- a/src/manifest-chrome.json
+++ b/src/manifest-chrome.json
@@ -22,7 +22,8 @@
     "*://*.youtube.com",
     "*://*.deezer.com",
     "*://*.app.plex.tv",
-    "*://*.hypem.com"
+    "*://*.hypem.com",
+    "*://*.tidal.com"
   ],
 
   "browser_action": {

--- a/src/manifest-edge.json
+++ b/src/manifest-edge.json
@@ -23,7 +23,7 @@
   "manifest_version": 2,
   "name": "Universal Now Playing Companion",
   "permissions": ["webRequest", "activeTab", "<all_urls>"],
-  "version": "1.0.0",
+  "version": "1.0.3",
   "-ms-preload": {
     "backgroundScript": "backgroundScriptsAPIBridge.js",
     "contentScript": "contentScriptsAPIBridge.js"

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -28,7 +28,8 @@
     "*://*.youtube.com",
     "*://*.deezer.com",
     "*://*.app.plex.tv",
-    "*://*.hypem.com"
+    "*://*.hypem.com",
+    "*://*.tidal.com"
   ],
   
   "browser_action": {

--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -3,7 +3,7 @@
 
   "name": "Universal Now Playing Companion",
   "description": "Browser helper for the desktop application, Universal Now Playing",
-  "version": "1.0.0",
+  "version": "1.0.3",
 
   "browser_specific_settings": {
     "gecko": {

--- a/src/worker-es6.js
+++ b/src/worker-es6.js
@@ -218,6 +218,28 @@ const youtubeMusic = () => {
   };
 };
 
+const tidal = () => {
+  const webPlayer = 'tidal';
+  const title = document.querySelector("[data-test='footer-track-title']")
+    .innerText;
+  const artist = document.querySelector(
+    "[data-test='grid-item-detail-text-title-artist']"
+  ).innerText;
+  const isPlaying = document.querySelector("[data-test='pause']");
+
+  if (isPlaying === null) {
+    return {
+      song: 'Paused',
+      webPlayer
+    };
+  }
+
+  return {
+    song: `${title} - ${artist}`,
+    webPlayer
+  };
+};
+
 const players = {
   mixcloud,
   pandora,
@@ -230,7 +252,8 @@ const players = {
   deezer,
   'app.plex.tv': plex,
   hypem,
-  bandcamp
+  bandcamp,
+  'listen.tidal.com': tidal
 };
 
 const sendToBackground = ({ song, webPlayer, isPaused }) => {


### PR DESCRIPTION
Also bump version.

Updating the Tidal handler if (when?) they change their test classes will be hard, since I will have to create a new trial account. So if someone wants to maintain this handler, I'd appreciate it :).

I will push this version to the Chrome store within the hour. Remember, you will have to update to the latest version of the desktop program to use new players.