### PR TITLE
youtube music wouldn't work (query selector returned null)

### DIFF
--- a/src/worker-es6.js
+++ b/src/worker-es6.js
@@ -198,10 +198,10 @@ const bandcamp = () => {
 const youtubeMusic = () => {
   const webPlayer = 'YouTube Music';
   const title = document.querySelector(
-    'yt-formatted-string.title.style-scope.ytmusic-player-bar.complex-string'
+    'yt-formatted-string.title.style-scope.ytmusic-player-bar'
   ).title;
   const byline = document.querySelector(
-    'yt-formatted-string.byline.style-scope.ytmusic-player-bar.complex-string'
+    'yt-formatted-string.byline.style-scope.ytmusic-player-bar'
   ).title;
   const isPlaying = document.querySelector('#play-pause-button');
 


### PR DESCRIPTION
removing that last bit seems to fix the query selector. (at least its working for me now after changing it in the "compiled" browser plugin for chrome)
I would love to see someone else test this out.